### PR TITLE
fix: Use Environment::matches() rather than == when selecting the trust anchor

### DIFF
--- a/src/lib/verifier.rs
+++ b/src/lib/verifier.rs
@@ -216,7 +216,7 @@ impl<'a, S: CorimStore<'a>> Verifier<'a, S> {
 
         for ev in self.corims.iter_ev() {
             for cond in &ev.condition {
-                if cond.environment.as_ref().unwrap() == id
+                if cond.environment.as_ref().unwrap().matches(id)
                     && let Some(elts) = &cond.element_list
                 {
                     for elt in elts {


### PR DESCRIPTION
The `Environment::matches()` function has more nuanced logic and is a better choice here than an equality check.
In fact, even the `Environment::matches()` function can produce false negatives right now, but that will be the right place to invest future changes.

Signed-off-by: Paul Howard <paul.howard@arm.com>