### PR TITLE
Consume corim-rs from the head revision and update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "corim-rs"
 version = "0.1.0"
-source = "git+https://github.com/veraison/corim-rs?rev=70893b6#70893b6ed402c73228f916cb0e906df2803fbb9d"
+source = "git+https://github.com/veraison/corim-rs#8d297d090521e1a8ee40c6a8bda97ff708e7302c"
 dependencies = [
  "base64 0.22.1",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ccatoken = { git = "https://github.com/veraison/rust-ccatoken", rev = "6d5b8db9"
 ciborium = "0.2.2"
 clap = { version = "4.5.32", features = ["derive"] }
 clap-verbosity-flag = "3.0.3"
-corim-rs = { git = "https://github.com/veraison/corim-rs", rev = "70893b6", features = ["openssl"] }
+corim-rs = { git = "https://github.com/veraison/corim-rs", features = ["openssl"] }
 cose-rust = { version = "0.1.7", features = ["serde_json"] }
 ear = { git = "https://github.com/veraison/rust-ear", rev = "15184e9a" }
 env_logger = { version = "0.11.8", features = ["kv"] }


### PR DESCRIPTION
Removes the `rev` directive for the `corim-rs` dependency, which allows consuming applications to reach the same dependency via multiple paths without encountering versioning issues.

Signed-off-by: Paul Howard <paul.howard@arm.com>